### PR TITLE
Fix line chart typing for historical data

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,6 +12,7 @@ import {
   Legend as ChartLegend,
   Filler,
   ChartOptions,
+  ChartData,
 } from 'chart.js';
 import {
   Radar,
@@ -207,22 +208,28 @@ const MemberInfoCard: React.FC<{ fiveTypeData: FiveTypeRecord[], historicalFiveT
   }, [fiveTypeData]);
 
   // Chart options for the five type history line chart
-  const lineChartFiveTypeData = {
-    labels: historicalFiveTypeData.map((item: { date: any; }) => item.date),
-    datasets: Object.keys(historicalFiveTypeData[0])
-      .filter(key => key !== 'date')
-      .map((key, index) => ({
-        label: key,
-        data: historicalFiveTypeData.map((item: { [x: string]: any; }) => item[key]),
-        borderColor: colors.chartColors[index % colors.chartColors.length],
-        backgroundColor: colors.chartColors[index % colors.chartColors.length].replace('0.6', '0.1'),
-        fill: false,
-        tension: 0.4,
-        borderWidth: 2,
-        pointRadius: 3,
-        pointHoverRadius: 5,
-      })),
-  };
+  const lineChartFiveTypeData: ChartData<'line'> = useMemo(() => {
+    if (historicalFiveTypeData.length === 0) {
+      return { labels: [], datasets: [] };
+    }
+
+    return {
+      labels: historicalFiveTypeData.map((item) => item.date),
+      datasets: Object.keys(historicalFiveTypeData[0])
+        .filter(key => key !== 'date')
+        .map((key, index) => ({
+          label: key,
+          data: historicalFiveTypeData.map(item => item[key] as number),
+          borderColor: colors.chartColors[index % colors.chartColors.length],
+          backgroundColor: colors.chartColors[index % colors.chartColors.length].replace('0.6', '0.1'),
+          fill: false,
+          tension: 0.4,
+          borderWidth: 2,
+          pointRadius: 3,
+          pointHoverRadius: 5,
+        }))
+    };
+  }, [historicalFiveTypeData]);
   
   const buttonStyle = {
     borderWidth: '1px',


### PR DESCRIPTION
## Summary
- typed `lineChartFiveTypeData` with Chart.js `ChartData`

## Testing
- `npm run lint` *(fails: next not found)*
- `npx -y tsc --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_683fc741a66c8327bbb0c0f9a15f8bb1